### PR TITLE
EL7 env doesn't support -S, use /usr/bin/expect instead

### DIFF
--- a/templates/wowza_install_script.exp.j2
+++ b/templates/wowza_install_script.exp.j2
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S expect -f
+#!/usr/bin/expect -f
 
 set timeout -1
 


### PR DESCRIPTION
Ubuntu/Debian and CentOS/RHEL both install expect as /usr/bin/expect, so
this shouldn't affect portability.

Thanks for publishing this role, so awesome!