### PR TITLE
Install on Ubuntu 20.04.1 server without error

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Please note: checking for already installed on the server Wowza Streaming Engine
 
 Requirements are listed in the role metadata.
 
+Client system that runs playbook needs python-bcrypt with `pip install bcrypt`.
+
 ## Role Variables
 
 ### Default role variables

--- a/tasks/wowza_config.yml
+++ b/tasks/wowza_config.yml
@@ -3,7 +3,7 @@
 - name: WSE files and directories permissions hardening  # noqa no-changed-when
   shell:
     cmd: 'set -eo pipefail && find /usr/local/WowzaStreamingEngine/ \( -type d -o -type f \) -print0 | xargs -0 chmod o-w'
-    executable: '/bin/sh'
+    executable: '/bin/bash'
 
 - name: Set read-only permissions for uninstall files
   file:

--- a/tasks/wowza_install.yml
+++ b/tasks/wowza_install.yml
@@ -15,7 +15,7 @@
     - wowza_installer_checksum | length > 0
 
 - name: Ensure expect is installed
-  package: name=expect state=installed
+  package: name=expect state=present
 
 - name: Create expect script on the server
   template:


### PR DESCRIPTION
These are the changes I had to make to get this playbook to run without errors on a fresh install of Ubuntu server 20.04.1 installed with the "alternative" D-I based installer for datacenter class server systems.