### PR TITLE
wse prior to 4.7.8 used the winstone servlet engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ wowza_manager_config_log4j: "{{ wowza_manager_config_directory }}/log4j.properti
 wowza_manager_config_log4j2: "{{ wowza_manager_config_directory }}/log4j2-config.xml"
 wowza_manager_config_log: "{{ wowza_manager_config_log4j2 if wowza_version is version('4.8.6', '>=') else wowza_manager_config_log4j }}"
 wowza_manager_config_tomcat_log4j: "{{ wowza_manager_config_directory }}/tomcat-log4j.properties"
+wowza_manager_config_winstone_log4j: "{{ wowza_manager_config_directory }}/winstone-log4j.properties"
+wowza_manager_config_servlet_log4j: "{{ wowza_manager_config_tomcat_log4j if wowza_version is version('4.7.8', '>=') else wowza_manager_config_winstone_log4j }}"
 
 wowza_config_files:
   - "{{ wowza_config_server }}"
@@ -99,7 +101,7 @@ wowza_config_files:
   - "{{ wowza_config_jmxremote_password }}"
   - "{{ wowza_config_log }}"
   - "{{ wowza_manager_config_log }}"
-  - "{{ wowza_manager_config_tomcat_log4j }}"
+  - "{{ wowza_manager_config_servlet_log4j }}"
 
 # Wowza Streaming Engine configs with sensitive data
 wowza_config_secret_files:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ wowza_users: []
 wowza_directory: "/usr/local/WowzaStreamingEngine"
 wowza_config_directory: "{{ wowza_directory }}/conf"
 wowza_manager_directory: "{{ wowza_directory }}/manager"
-wowza_manager_counfig_directory: "{{ wowza_manager_directory }}/conf"
+wowza_manager_config_directory: "{{ wowza_manager_directory }}/conf"
 wowza_applications_directory: "{{ wowza_directory }}/applications"
 wowza_lib_directory: "{{ wowza_directory }}/lib"
 wowza_log_directory: "/var/log/wowza"
@@ -81,10 +81,10 @@ wowza_config_jmxremote_password: "{{ wowza_config_directory }}/jmxremote.passwor
 wowza_config_log4j: "{{ wowza_config_directory }}/log4j.properties"
 wowza_config_log4j2: "{{ wowza_config_directory }}/log4j2-config.xml"
 wowza_config_log: "{{ wowza_config_log4j2 if wowza_version is version('4.8.6', '>=') else wowza_config_log4j }}"
-wowza_manager_config_log4j: "{{ wowza_manager_counfig_directory }}/log4j.properties"
-wowza_manager_config_log4j2: "{{ wowza_manager_counfig_directory }}/log4j2-config.xml"
+wowza_manager_config_log4j: "{{ wowza_manager_config_directory }}/log4j.properties"
+wowza_manager_config_log4j2: "{{ wowza_manager_config_directory }}/log4j2-config.xml"
 wowza_manager_config_log: "{{ wowza_manager_config_log4j2 if wowza_version is version('4.8.6', '>=') else wowza_manager_config_log4j }}"
-wowza_manager_config_tomcat_log4j: "{{ wowza_manager_counfig_directory }}/tomcat-log4j.properties"
+wowza_manager_config_tomcat_log4j: "{{ wowza_manager_config_directory }}/tomcat-log4j.properties"
 
 wowza_config_files:
   - "{{ wowza_config_server }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,7 @@ wowza_users: []
 wowza_directory: "/usr/local/WowzaStreamingEngine"
 wowza_config_directory: "{{ wowza_directory }}/conf"
 wowza_manager_directory: "{{ wowza_directory }}/manager"
-wowza_manager_counfig_directory: "{{ wowza_manager_directory }}/conf"
+wowza_manager_config_directory: "{{ wowza_manager_directory }}/conf"
 wowza_applications_directory: "{{ wowza_directory }}/applications"
 wowza_lib_directory: "{{ wowza_directory }}/lib"
 wowza_log_directory: "/var/log/wowza"
@@ -60,10 +60,10 @@ wowza_config_jmxremote_password: "{{ wowza_config_directory }}/jmxremote.passwor
 wowza_config_log4j: "{{ wowza_config_directory }}/log4j.properties"
 wowza_config_log4j2: "{{ wowza_config_directory }}/log4j2-config.xml"
 wowza_config_log: "{{ wowza_config_log4j2 if wowza_version is version('4.8.6', '>=') else wowza_config_log4j }}"
-wowza_manager_config_log4j: "{{ wowza_manager_counfig_directory }}/log4j.properties"
-wowza_manager_config_log4j2: "{{ wowza_manager_counfig_directory }}/log4j2-config.xml"
+wowza_manager_config_log4j: "{{ wowza_manager_config_directory }}/log4j.properties"
+wowza_manager_config_log4j2: "{{ wowza_manager_config_directory }}/log4j2-config.xml"
 wowza_manager_config_log: "{{ wowza_manager_config_log4j2 if wowza_version is version('4.8.6', '>=') else wowza_manager_config_log4j }}"
-wowza_manager_config_tomcat_log4j: "{{ wowza_manager_counfig_directory }}/tomcat-log4j.properties"
+wowza_manager_config_tomcat_log4j: "{{ wowza_manager_config_directory }}/tomcat-log4j.properties"
 
 wowza_config_files:
   - "{{ wowza_config_server }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -63,7 +63,10 @@ wowza_config_log: "{{ wowza_config_log4j2 if wowza_version is version('4.8.6', '
 wowza_manager_config_log4j: "{{ wowza_manager_config_directory }}/log4j.properties"
 wowza_manager_config_log4j2: "{{ wowza_manager_config_directory }}/log4j2-config.xml"
 wowza_manager_config_log: "{{ wowza_manager_config_log4j2 if wowza_version is version('4.8.6', '>=') else wowza_manager_config_log4j }}"
+
 wowza_manager_config_tomcat_log4j: "{{ wowza_manager_config_directory }}/tomcat-log4j.properties"
+wowza_manager_config_winstone_log4j: "{{ wowza_manager_config_directory }}/winstone-log4j.properties"
+wowza_manager_config_servlet_log4j: "{{ wowza_manager_config_tomcat_log4j if wowza_version is version('4.7.8', '>=') else wowza_manager_config_winstone_log4j }}"
 
 wowza_config_files:
   - "{{ wowza_config_server }}"
@@ -78,7 +81,7 @@ wowza_config_files:
   - "{{ wowza_config_jmxremote_password }}"
   - "{{ wowza_config_log }}"
   - "{{ wowza_manager_config_log }}"
-  - "{{ wowza_manager_config_tomcat_log4j }}"
+  - "{{ wowza_manager_config_servlet_log4j }}"
 
 # Wowza Streaming Engine configs with sensitive data
 wowza_config_secret_files:

--- a/tasks/wowza_config.yml
+++ b/tasks/wowza_config.yml
@@ -64,7 +64,7 @@
     backup: false
   loop:
     - '{{ wowza_manager_config_log }}'
-    - '{{ wowza_manager_config_tomcat_log4j }}'
+    - '{{ wowza_manager_config_servlet_log4j }}'
   notify: wowza restart wse manager
 
 - name: Fix windows CR EOL in WSE configs


### PR DESCRIPTION
https://www.wowza.com/docs/wowza-streaming-engine-4-7-8-release-notes

> Stopped using the Winstone servlet container in Wowza Streaming Engine Manager
> Due to security concerns, Wowza Streaming Engine 4.7.8 discontinued the use of the Winstone servlet container in Wowza Streaming Engine Manager. Instead, Wowza Streaming Engine Manager 4.7.8 and later uses Apache Tomcat 9.0 as the servlet container. The winstone.properties file has been replaced with tomcat.properties; the content of the files is nearly identical, but the name has changed. For more information, see Connect to Wowza Streaming Engine Manager over HTTPS.

..also fixed typos